### PR TITLE
[RFC] Pull for automatic compilation database finding and better directory control

### DIFF
--- a/README.org
+++ b/README.org
@@ -53,5 +53,7 @@
     - =flycheck-clangcheck-extra-arg-before= :: Additional argument to prepend to the compiler command line for ClangCheck.
 
     - =flycheck-clangcheck-fatal-assembler-warnings= :: Whether to enable Considering warning as error to C/C++ in ClangCheck.
+
+    - =flycheck-clangcheck-dbname= :: The name of the [[http://clang.llvm.org/docs/JSONCompilationDatabase.html][JSON Compilation Database]] (default =compile_commands.json=).
       
-    - =flycheck-clangcheck-build-path= :: Build directory for ClangCheck. If this is defined, a [[http://clang.llvm.org/docs/JSONCompilationDatabase.html][JSON Compilation Database]] (=compile_commands.json=) must be placed to there.
+    - =flycheck-clangcheck-build-path= :: Build directory for ClangCheck. If this is defined, a [[http://clang.llvm.org/docs/JSONCompilationDatabase.html][JSON Compilation Database]] (=flycheck-clangcheck-dbname=) must be placed to there.

--- a/flycheck-clangcheck.el
+++ b/flycheck-clangcheck.el
@@ -145,11 +145,16 @@ See URL `http://clang.llvm.org/docs/ClangCheck.html'."
                             (flycheck-clangcheck-get-json
                              flycheck-clangcheck-build-path
                              (buffer-file-name))))
-                       ;; for side-effect only
-                       (flycheck-clangcheck-set-build-dir json)
-
-                       ;; return the commands
-                       (flycheck-clangcheck-get-compile-command json)))
+                       (if json
+                           (progn
+                             ;; for side-effect only
+                             (flycheck-clangcheck-set-build-dir json)
+                             ;; return the commands
+                             (flycheck-clangcheck-get-compile-command
+                              json))
+                         (progn (message "Couldn't find compile
+  command from `compile_commands.json' in %s." flycheck-clangcheck-build-path)
+                                nil))))
                  (concat "-x"
                          (cl-case major-mode
                            (c++-mode "c++")

--- a/flycheck-clangcheck.el
+++ b/flycheck-clangcheck.el
@@ -28,6 +28,14 @@
 (require 'json)
 (require 'flycheck)
 
+(flycheck-def-option-var flycheck-clangcheck-dbname "compile_commands.json" c/c++-clangcheck
+  "Name of the compile commands database for ClangCheck.
+
+The value of this variable is a string, describing
+a name of the build commands database."
+  :type '(file :tag "Compile database")
+  :safe #'stringp)
+
 (flycheck-def-option-var flycheck-clangcheck-analyze nil c/c++-clangcheck
   "Whether to enable Static Analysis to C/C++ in ClangCheck.
 
@@ -71,8 +79,8 @@ a build directory where `compile_commands.json' exists."
   :safe #'stringp)
 
 (defun flycheck-clangcheck-get-compile-command (build-dir source)
-  "Get a list of compile commands from `compile_commands.json' at BUILD-DIR for SOURCE."
-  (let ((commands (json-read-file (expand-file-name "compile_commands.json"
+  "Get a list of compile commands from `flycheck-clangcheck-dbname' at BUILD-DIR for SOURCE."
+  (let ((commands (json-read-file (expand-file-name flycheck-clangcheck-dbname
 						    build-dir)))
 	(source-truename (file-truename source)))
     (let ((found (cl-find-if (lambda (item)


### PR DESCRIPTION
This fixes my issues with QEMU's build structure (where the compiler runs in a different build directory than the source file, see #1 ).  I'm making this an RFC pull request as I'm sure you'll want to make some comments on the way I've hacked this up ;-)

I'm not overly happy with the name clangcheck-build-path as build and compile db location could be two different things.
