### PR TITLE
Compatibility fixes for WAF and bear

### DIFF
--- a/flycheck-clangcheck.el
+++ b/flycheck-clangcheck.el
@@ -98,7 +98,9 @@ Return the directory which contains the database or nil."
 	(source-truename (file-truename source)))
     (cl-find-if (lambda (item)
                   (string= source-truename
-                           (file-truename (cdr (assq 'file item)))))
+                           (file-truename
+			    (expand-file-name (cdr (assq 'file item))
+					      (cdr (assq 'directory item))))))
                 commands)))
 
 (defun flycheck-clangcheck-get-compile-command (json)

--- a/flycheck-clangcheck.el
+++ b/flycheck-clangcheck.el
@@ -109,8 +109,11 @@ Return the directory which contains the database or nil."
 
 We apply some basic filters to avoid weird cases."
   (if json
-      (let ((raw-cmds (split-string-and-unquote (cdr (assq 'command json))))
-            (skip-next nil))
+      (let* ((command (cdr (assq 'command json)))
+	     (raw-cmds (if command
+			   (split-string-and-unquote command)
+			 (cdr (assq 'arguments json))))
+             (skip-next nil))
         (seq-filter (lambda (it)
                       (cond
                        ;; Don't output dependencies as this will likely confuse


### PR DESCRIPTION
Two compatibility fixes that should be backward compatible.   The first helps flycheck-clangcheck work with build systems, such as WAF, that build in a a subdirectory.  The second allows the use of compile_commands.json files created using the bear(1) command.